### PR TITLE
Add libsedml to conda pkg requirements

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -10,6 +10,7 @@ requirements:
     - roadrunner
     - antimony
     - phrasedml
+    - libsedml
 
 about:
   home: http://tellurium.analogmachine.org/


### PR DESCRIPTION
* libsedml is now on the sys-bio channel for OS X and Linux-64