### PR TITLE
Fixed missing linalg in nullspace() function of tellurium/utils/matrix.py

### DIFF
--- a/tellurium/utils/matrix.py
+++ b/tellurium/utils/matrix.py
@@ -81,7 +81,7 @@ def nullspace(A, atol=1e-13, rtol=0):
     """
 
     A = np.atleast_2d(A)
-    u, s, vh = np.svd(A)
+    u, s, vh = np.linalg.svd(A)
     tol = max(atol, rtol * s[0])
     nnz = (s >= tol).sum()
     ns = vh[nnz:].conj().T


### PR DESCRIPTION
Changed np.svd(A) to np.linalg.svd(A) in the nullspace function, as this was not working, even though it's correct in the rank function