### PR TITLE
Fixed NameError in getODEsFromSBMLFile()

### DIFF
--- a/tellurium/utils/misc.py
+++ b/tellurium/utils/misc.py
@@ -88,7 +88,7 @@ def getODEsFromSBMLFile (fileName):
     
     >>> te.getODEsFromSBMLFile ('mymodel.xml')
     """
-    sbmlStr = te.readFromFile (fileName)
+    sbmlStr = readFromFile (fileName)
     extractor = ODEExtractor (sbmlStr)
     return extractor.toString()
     


### PR DESCRIPTION
This concerns the function `getODEsFromSBMLFile()` within `tellurium.utils.misc`. Calling the function throws `NameError: name 'te' is not defined`, because of an erroneously-defined call to `te.readFromFile()`, which has now been modified to just `readFromFile()`. 
