### PR TITLE
remove 'seed' parameter from gillespie signature

### DIFF
--- a/tellurium/roadrunner/extended_roadrunner.py
+++ b/tellurium/roadrunner/extended_roadrunner.py
@@ -459,8 +459,6 @@ class ExtendedRoadRunner(roadrunner.RoadRunner):
             result = rr.gillespie (0, 40, 20, ['time', 'S1'])
             rr.plot(result)
 
-        :param seed: seed for gillespie
-        :type seed: int
         :param args: parameters for simulate
         :param kwargs: parameters for simulate
         :returns: simulation results


### PR DESCRIPTION
This tiny fix addresses roadrunner issue [\#578](https://github.com/sys-bio/roadrunner/issues/578).