### PR TITLE
Change variable name numberOfPoints to numberOfSteps to match meaning…

### DIFF
--- a/tellurium/sedml/tesedml.py
+++ b/tellurium/sedml/tesedml.py
@@ -1123,7 +1123,7 @@ class SEDMLCodeFactory(object):
             initialTime = simulation.getInitialTime()
             outputStartTime = simulation.getOutputStartTime()
             outputEndTime = simulation.getOutputEndTime()
-            numberOfPoints = simulation.getNumberOfPoints()
+            numberOfSteps = simulation.getNumberOfSteps()
 
             # reset before simulation (see https://github.com/sys-bio/tellurium/issues/193)
             lines.append("{}.reset()".format(mid))
@@ -1134,7 +1134,7 @@ class SEDMLCodeFactory(object):
                                     mid, initialTime, outputStartTime))
             # real simulation
             lines.append("{} = {}.simulate(start={}, end={}, steps={})".format(
-                                    resultVariable, mid, outputStartTime, outputEndTime, numberOfPoints))
+                                    resultVariable, mid, outputStartTime, outputEndTime, numberOfSteps))
         # -------------------------------------------------------------------------
         # <ONESTEP>
         # -------------------------------------------------------------------------


### PR DESCRIPTION
Changed the variable called numberOfPoints to numberOfSteps in tesedml.py. The variable is used shortly afterward to create a roadrunner command using the steps keyword, therefore it is better to use numberOfSteps here instead of the original numberOfPoints. A basic test of the code was performed (not supplied) to make sure it worked.  There probably should be a way to submit tests alongside changes. 